### PR TITLE
Update URL permissions

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -29,7 +29,10 @@
       "38": "images/icon-38.png"
     },
     "default_title": "__MSG_browserActionTitle__",
-    "default_popup": "pages/popup.html"
+    "default_popup": "pages/popup.html",
+    "__firefox__show_matches": [
+      "*://mg.blogvault.net/migration/*"
+    ]
   },
   "options_ui": {
     "page": "pages/options.html",
@@ -38,8 +41,7 @@
   "content_scripts": [
     {
       "matches": [
-        "http://*/*",
-        "https://*/*"
+        "*://mg.blogvault.net/migration/*"
       ],
       "css": [
         "styles/contentscript.css"
@@ -55,6 +57,6 @@
     "notifications",
     "storage",
     "tabs",
-    "<all_urls>"
+    "*://mg.blogvault.net/migration/*"
   ]
 }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1,9 +1,19 @@
+const MIGRATE_GURU_HOSTNAME = 'mg.blogvault.net';
+const MIGRATE_GURU_PATHNAME = '/migration/';
+
 browser.runtime.onInstalled.addListener((details) => {
   console.log('previousVersion', details.previousVersion)
 })
 
-browser.tabs.onUpdated.addListener(async (tabId) => {
-  browser.pageAction.show(tabId)
-})
+if (process.env.VENDOR !== 'firefox') {
+  browser.tabs.onUpdated.addListener(async (tabId, _change, tab) => {
+    const url = new URL(tab.url)
+    if (url.hostname === MIGRATE_GURU_HOSTNAME && url.pathname.startsWith(MIGRATE_GURU_PATHNAME)) {
+      browser.pageAction.show(tabId);
+    } else {
+      browser.pageAction.hide(tabId);
+    }
+  });
+}
 
 console.log(`'Allo 'Allo! Event Page for Page Action`)


### PR DESCRIPTION
- Narrow the page action and content script match pattern to only apply to individual Migrate Guru migration pages
- Narrow the permissions to only include a match pattern permission for individual Migrate Guru migration pages
- In Firefox, use the declarative `show_matches` key for the page action