### PR TITLE
Remove `npm test` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "open:firefox": "wait-on dist/firefox/manifest.json && ./scripts/clean-env web-ext run -s dist/firefox",
     "open:chrome": "wait-on dist/chrome/manifest.json && ./scripts/open-chrome dist/chrome",
     "build": "webextension-toolbox build",
-    "test": "echo \"Error: no test specified\" && exit 1",
     "lint:firefox": "./scripts/clean-env web-ext lint -w -s ./dist/firefox",
     "submit:firefox": "web-ext sign -s ./dist/firefox/ -a ./packages/",
     "preversion": "./scripts/version-bump/run-preversion",


### PR DESCRIPTION
Since no tests are set up right now, remove the failing `npm test` script.