### PR TITLE
Fix default values in options view

### DIFF
--- a/app/scripts/popup/option-list-item.svelte
+++ b/app/scripts/popup/option-list-item.svelte
@@ -6,7 +6,7 @@
   export let setting;
 
   // stores can't be created in reactive declarations
-  const enabled = create_setting_store(setting, true);
+  const enabled = create_setting_store(setting);
 
   $: value_message_key = $enabled ? 'popupEnabledListItem' : 'popupDisabledListItem';
 </script>

--- a/app/scripts/shared/settings.js
+++ b/app/scripts/shared/settings.js
@@ -1,6 +1,13 @@
 import { readable } from "svelte/store";
 
-export function create_setting_store(key, default_value) {
+const DEFAULTS = {
+  notifications: true,
+  favicons: true
+}
+
+export function create_setting_store(key) {
+  const default_value = DEFAULTS[key];
+
   async function initialize(set) {
     const { [key]: value } = await browser.storage.local.get({ [key]: default_value });
     set(value);


### PR DESCRIPTION
Fix the default value of the options checkboxes by centralizing the definition of default settings values.